### PR TITLE
Add $orange-red As Danger Theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "net-style",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Base Bootstrap file for Netchex",
   "main": "index.html",
   "author": "",

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -73,6 +73,7 @@ $dark-blue:     #015782 !default;
 $yellow:        #ffffcc !default;
 $orange:        #fb6b5b !default;
 $red:           #990000 !default;
+$orange-red:    #d85556 !default;
 $indigo:        #6610f2 !default;
 $purple:        #6f42c1 !default;
 $pink:          #fdb5ad !default;
@@ -126,7 +127,7 @@ $theme-colors: (
     info: $cyan,
     warning: $yellow,
     caution: $orange,
-    danger: $red,
+    danger: $orange-red,
     light: $gray-300,
     dark: $gray-800
 ) !default;


### PR DESCRIPTION
Based on request in AzDo story `109603`.

- added `$orange-red #d85556`
- set `$theme-colors.danger = $orange-red`
- bump package version to `0.0.3`

Please advise on package version update. Should this be a minor or even major update?